### PR TITLE
Fixes Listing Info Retrieval Handling when Slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 web-ext-artifacts/
+.idea

--- a/float.js
+++ b/float.js
@@ -169,7 +169,7 @@ const getFloatButtonClicked = function(e) {
         floatQueue.push({ listingId: id, inspectLink: inspectLink });
     },
     () => {
-        setFloatText(id, "Failed to obtain listing info, please try again");
+        setFloatText(id, 'Failed to obtain listing info, please try again');
     });
 };
 

--- a/float.js
+++ b/float.js
@@ -15,14 +15,18 @@ const retrieveListingInfoFromPage = function(listingId) {
         return Promise.resolve(steamListingInfo[listingId]);
     }
 
+    // Reset, since this is a new page
+    steamListingInfo = {};
+
     window.postMessage({
         type: 'requestListingInfo'
     }, '*');
 
     return new Promise((resolve, reject) => {
         setTimeout(() => {
-            resolve((listingId != null) ? steamListingInfo[listingId] : steamListingInfo);
-        }, 0);
+            if (Object.keys(steamListingInfo).length === 0) reject();
+            else resolve((listingId != null) ? steamListingInfo[listingId] : steamListingInfo);
+        }, 10);
     });
 };
 
@@ -33,24 +37,30 @@ const getFloatData = function(listingId, inspectLink) {
 
     return fetch(`https://api.csgofloat.com:1738/?url=${inspectLink}`)
     .then((response) => {
-        if (response.ok) { return response.json(); }
+        if (response.ok) return response.json();
         return response.json().then((err) => { throw err; });
     });
 };
 
-const showFloatText = function(listingId) {
+const showFloat = function(listingId) {
+    let itemInfo = floatData[listingId];
+
+    if (itemInfo) setFloatText(listingId, `Float: ${itemInfo.floatvalue}<br>Paint Seed: ${itemInfo.paintseed}`, true);
+};
+
+const setFloatText = function(listingId, text, removeButton) {
     let floatDiv = document.querySelector(`#item_${listingId}_floatdiv`);
 
     if (floatDiv) {
-        // Remove the "get float" button
-        let floatButton = floatDiv.querySelector('.floatbutton');
-        if (floatButton) { floatDiv.removeChild(floatButton); }
+        if (removeButton) {
+            // Remove the "get float" button
+            let floatButton = floatDiv.querySelector('.floatbutton');
+            if (floatButton) { floatDiv.removeChild(floatButton); }
+        }
 
-        let itemInfo = floatData[listingId];
-
-        // Show the float and paint seed to the user
+        // Show the text to the user
         let msgdiv = floatDiv.querySelector('.floatmessage');
-        msgdiv.innerHTML = `Float: ${itemInfo.floatvalue}<br>Paint Seed: ${itemInfo.paintseed}`;
+        msgdiv.innerHTML = text;
     }
 };
 
@@ -73,11 +83,9 @@ const processFloatQueue = function() {
 
     getFloatData(lastItem.listingId, lastItem.inspectLink)
     .then((data) => {
-        let itemInfo = data.iteminfo;
+        floatData[lastItem.listingId] = data.iteminfo;
 
-        floatData[lastItem.listingId] = itemInfo;
-
-        showFloatText(lastItem.listingId);
+        showFloat(lastItem.listingId);
 
         processFloatQueue();
     })
@@ -112,6 +120,10 @@ const getAllFloats = function() {
 
             floatQueue.push({ listingId: id, inspectLink: inspectLink });
         }
+    },
+    () => {
+        // Try again
+        getAllFloats();
     });
 };
 
@@ -155,6 +167,9 @@ const getFloatButtonClicked = function(e) {
         .replace('%assetid%', listingData.asset.id);
 
         floatQueue.push({ listingId: id, inspectLink: inspectLink });
+    },
+    () => {
+        setFloatText(id, "Failed to obtain listing info, please try again");
     });
 };
 
@@ -193,7 +208,7 @@ const addButtons = function() {
 
         // check if we already have the float for this item
         if (id in floatData) {
-            showFloatText(id);
+            showFloat(id);
         }
     }
 
@@ -223,5 +238,5 @@ floatTimer = setInterval(() => { addButtons(); }, 500);
 processFloatQueue();
 
 const logStyle = 'background: #222; color: #fff;';
-console.log('%c CSGOFloat Market Checker (v1.1.0) by Step7750 ', logStyle);
+console.log('%c CSGOFloat Market Checker (v1.1.1) by Step7750 ', logStyle);
 console.log('%c Changelog can be found here: https://github.com/Step7750/CSGOFloat-Extension ', logStyle);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "CSGOFloat Market Checker",
     "short_name": "CSGOFloat",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Dedicated API for fetching the float value and paint seed of CSGO items on the market",
     "icons": {
         "16": "icons/16.png",


### PR DESCRIPTION
Issue: 
Sometimes the page doesn't reply with listing info fast enough and `retrieveListingInfoFromPage` returns null data in the promise.

Fix: 
Delays the timeout for retrieving to 10ms. In the vast majority of
cases, it will be retrieved in under 10ms. If it still takes longer,
`retrieveListingInfoFromPage` rejects the promise. If the promise is
rejected for a single listing, the listing text is updated (to prevent
an infinite loop if they're on a new page). If the promise is rejected
for 'Get all floats', it tries again.