### PR TITLE
Fixes Selector when User Has Items on Sale

### DIFF
--- a/float.js
+++ b/float.js
@@ -110,7 +110,7 @@ const getAllFloats = function() {
     retrieveListingInfoFromPage()
     .then((steamListingData) => {
         // Get all current items on the page (in proper order)
-        let listingRows = document.querySelectorAll('.market_listing_row.market_recent_listing_row');
+        let listingRows = document.querySelectorAll('#searchResultsRows .market_listing_row.market_recent_listing_row');
 
         for (let row of listingRows) {
             let id = row.id.replace('listing_', '');
@@ -176,7 +176,7 @@ const getFloatButtonClicked = function(e) {
 // If an item on the current page doesn't have the float div/buttons, this function adds it
 const addButtons = function() {
     // Iterate through each item on the page
-    let listingRows = document.querySelectorAll('.market_listing_row.market_recent_listing_row');
+    let listingRows = document.querySelectorAll('#searchResultsRows .market_listing_row.market_recent_listing_row');
 
     for (let row of listingRows) {
         let id = row.id.replace('listing_', '');


### PR DESCRIPTION
A Fix for community market item listing pages where the user has items for sale.

Steam added a feature where it displays items you are selling directly on the item page, it broke the plugin on items where you have items listed. I've added a more specific selector to fix the issue.