### PR TITLE
Removes Keys With No Filters

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -391,7 +391,16 @@ class Filters {
         let storageType = chrome.storage.sync;
         if (!storageType) storageType = chrome.storage.local;
 
-        storageType.set(syncFilters);
+        if (filterArray.length === 0) {
+            storageType.remove(key);
+        } else {
+            storageType.set(syncFilters, () => {
+                if (chrome.runtime.lastError) {
+                    alert('Error occurred while saving, you may have to remove some filters and try again\n' +
+                           chrome.runtime.lastError.toString())
+                }
+            });
+        }
 
         // update UI
         removeButtons();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,3 +53,79 @@ const pickTextColour = function(bgColor, lightColour, darkColour) {
     return (L > 0.179) ? darkColour : lightColour;
 };
 
+/**
+ * Compares two software version numbers (e.g. "1.7.1" or "1.2b").
+ *
+ * This function was born in http://stackoverflow.com/a/6832721.
+ *
+ * @param {string} v1 The first version to be compared.
+ * @param {string} v2 The second version to be compared.
+ * @param {object} [options] Optional flags that affect comparison behavior:
+ * <ul>
+ *     <li>
+ *         <tt>lexicographical: true</tt> compares each part of the version strings lexicographically instead of
+ *         naturally; this allows suffixes such as "b" or "dev" but will cause "1.10" to be considered smaller than
+ *         "1.2".
+ *     </li>
+ *     <li>
+ *         <tt>zeroExtend: true</tt> changes the result if one version string has less parts than the other. In
+ *         this case the shorter string will be padded with "zero" parts instead of being considered smaller.
+ *     </li>
+ * </ul>
+ * @returns {number|NaN}
+ * <ul>
+ *    <li>0 if the versions are equal</li>
+ *    <li>a negative integer iff v1 < v2</li>
+ *    <li>a positive integer iff v1 > v2</li>
+ *    <li>NaN if either version string is in the wrong format</li>
+ * </ul>
+ *
+ * @copyright by Jon Papaioannou (["john", "papaioannou"].join(".") + "@gmail.com")
+ * @license This function is in the public domain. Do what you want with it, no strings attached.
+ */
+function versionCompare(v1, v2, options) {
+    var lexicographical = options && options.lexicographical,
+        zeroExtend = options && options.zeroExtend,
+        v1parts = v1.split('.'),
+        v2parts = v2.split('.');
+
+    function isValidPart(x) {
+        return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
+    }
+
+    if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
+        return NaN;
+    }
+
+    if (zeroExtend) {
+        while (v1parts.length < v2parts.length) v1parts.push("0");
+        while (v2parts.length < v1parts.length) v2parts.push("0");
+    }
+
+    if (!lexicographical) {
+        v1parts = v1parts.map(Number);
+        v2parts = v2parts.map(Number);
+    }
+
+    for (var i = 0; i < v1parts.length; ++i) {
+        if (v2parts.length == i) {
+            return 1;
+        }
+
+        if (v1parts[i] == v2parts[i]) {
+            continue;
+        }
+        else if (v1parts[i] > v2parts[i]) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+
+    if (v1parts.length != v2parts.length) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "CSGOFloat Market Checker",
     "short_name": "CSGOFloat",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Dedicated API for fetching the float value and paint seed of CSGO items on the market",
     "icons": {
         "16": "icons/16.png",


### PR DESCRIPTION
* Upon first startup with the new version, it'll delete all keys with no filters
* Removing all filters on a page now removes the key

Fixes #20 

This is only applicable to users with filters on >512 unique guns