### PR TITLE
Fix for Duplicate Utility Bars

### DIFF
--- a/float.js
+++ b/float.js
@@ -437,8 +437,6 @@ const addFloatUtilities = async function() {
     document
         .querySelector('#searchResultsTable')
         .insertBefore(csmoneyDiv, document.querySelector('#searchResultsRows'));
-
-    floatUtilitiesAdded = true;
 };
 
 const removeInventoryButtons = function(parent) {
@@ -699,6 +697,7 @@ const addMarketButtons = async function() {
 
     // Add float utilities if it doesn't exist and we have valid items
     if (!floatUtilitiesAdded && listingRows.length > 0) {
+        floatUtilitiesAdded = true;
         addFloatUtilities();
     }
 


### PR DESCRIPTION
The event loop can sometimes cause two or more bars to be added if communication to the page is slow. This PR ensures that the flag is flipped right away without waiting for any potential page data within the `addFloatUtilities()`

Fixes #50 