### PR TITLE
Fixes Undefined Image With Comma Stickers

### DIFF
--- a/float.js
+++ b/float.js
@@ -672,7 +672,7 @@ const addMarketButtons = async function() {
 
                 // Adds href link to sticker
                 let resHtml = '';
-                for (let i = 0; i < stickerNames.length; i++) {
+                for (let i = 0; i < imagesHtml.length; i++) {
                     const url = stickerLang === 'Sticker' ?
                         `https://steamcommunity.com/market/listings/730/${stickerLang} | ${stickerNames[i]}` :
                         `https://steamcommunity.com/market/search?q=${stickerLang} | ${stickerNames[i]}`;


### PR DESCRIPTION
We can't know how to split the sticker string for certain if there are commas, but this will prevent issues of undefined images in this case. 

Closes #49 