### PR TITLE
Implements FloatDB Ranks

### DIFF
--- a/float.css
+++ b/float.css
@@ -141,3 +141,47 @@ input[type='color']::-webkit-color-swatch {
 .float-tooltip:hover .tiptext {
     visibility: visible;
 }
+
+.float-shine {
+    overflow: hidden;
+}
+
+/* Based on https://jsfiddle.net/AntonTrollback/nqQc7/ */
+.float-shine:after {
+    animation: shine 4s ease-in-out infinite;
+    content: "";
+    position: absolute;
+    top: -110%;
+    left: -210%;
+    width: 200%;
+    height: 200%;
+    opacity: 0;
+    transform: rotate(30deg);
+
+    background: rgba(255, 255, 255, 0.13);
+    background: linear-gradient(
+            to right,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0.13) 77%,
+            rgba(255, 255, 255, 0.5) 92%,
+            rgba(255, 255, 255, 0) 100%
+    );
+}
+
+@keyframes shine{
+    50% {
+        opacity: 1;
+        top: -30%;
+        left: -30%;
+        transition-property: left, top, opacity;
+        transition-duration: 0.7s, 0.7s, 0.15s;
+        transition-timing-function: ease;
+    }
+    100% {
+        opacity: 0;
+        top: -30%;
+        left: -30%;
+        transition-property: left, top, opacity;
+    }
+}
+

--- a/float.js
+++ b/float.js
@@ -293,13 +293,15 @@ const showFloat = async function(listingId) {
             phase: (getDopplerPhase(itemInfo.paintindex) || '').replace('Phase', '').trim()
         };
 
-        // Check to see if there is a filter match
-        let filterColour = await filters.getMatchColour(vars);
+        if (!isInventoryPage()) {
+            // Check to see if there is a filter match
+            let filterColour = await filters.getMatchColour(vars);
 
-        if (filterColour) {
-            const textColour = pickTextColour(filterColour, '#8F98A0', '#484848');
-            floatDiv.parentNode.parentNode.style.backgroundColor = filterColour;
-            floatDiv.style.color = textColour;
+            if (filterColour) {
+                const textColour = pickTextColour(filterColour, '#8F98A0', '#484848');
+                floatDiv.parentNode.parentNode.style.backgroundColor = filterColour;
+                floatDiv.style.color = textColour;
+            }
         }
     }
 };

--- a/float.js
+++ b/float.js
@@ -237,9 +237,11 @@ const showFloat = async function(listingId) {
                 ? itemInfo.floatvalue.toFixed(6)
                 : `Float: ${itemInfo.floatvalue.toFixed(14)}`;
 
-            const rank = itemInfo.low_rank || itemInfo.high_rank;
+            // Get whichever is the lower rank
+            const rank = (itemInfo.low_rank || 1001) < (itemInfo.high_rank || 1001) ?
+                itemInfo.low_rank : itemInfo.high_rank;
 
-            if (rank) {
+            if (rank && rank <= 1000) {
                 if (floatDiv.minimal) {
                     floatText += ` (#${rank})`;
                 } else {

--- a/float.js
+++ b/float.js
@@ -201,6 +201,21 @@ const retrieveInventoryOwner = function() {
     });
 };
 
+const getRankColour = function (rank) {
+    switch (rank) {
+        case 1:
+            return '#c3a508';
+        case 2:
+        case 3:
+            return '#9a9999';
+        case 4:
+        case 5:
+            return '#8a5929';
+        default:
+            return '';
+    }
+};
+
 const showFloat = async function(listingId) {
     let itemInfo = floatData[listingId];
 
@@ -218,9 +233,28 @@ const showFloat = async function(listingId) {
         // Add the float value
         let itemFloatDiv = floatDiv.querySelector('.csgofloat-itemfloat');
         if (itemFloatDiv) {
-            itemFloatDiv.innerText = floatDiv.minimal
+            let floatText = floatDiv.minimal
                 ? itemInfo.floatvalue.toFixed(6)
-                : `Float: ${itemInfo.floatvalue}`;
+                : `Float: ${itemInfo.floatvalue.toFixed(14)}`;
+
+            const rank = itemInfo.low_rank || itemInfo.high_rank;
+
+            if (rank) {
+                if (floatDiv.minimal) {
+                    floatText += ` (#${rank})`;
+                } else {
+                    floatText += ` (Rank #${rank})`;
+                }
+            }
+
+            itemFloatDiv.innerText = floatText;
+
+            if (rank <= 5 && floatDiv.minimal) {
+                // Make the inventory box coloured ;)
+                floatDiv.parentNode.style.color = 'black';
+                floatDiv.parentNode.querySelector('img').style.backgroundColor = getRankColour(rank);
+                floatDiv.parentNode.classList.add('float-shine');
+            }
         }
 
         // Add the paint seed
@@ -626,7 +660,7 @@ const addInventoryBoxes = async function() {
                 floatSpan.style.position = 'absolute';
                 floatSpan.style.bottom = '3px';
                 floatSpan.style.right = '3px';
-                floatSpan.style.fontSize = '13px';
+                floatSpan.style.fontSize = '12px';
                 floatSpan.classList.add('csgofloat-itemfloat');
 
                 const seedSpan = document.createElement('span');

--- a/float.js
+++ b/float.js
@@ -290,7 +290,9 @@ const showFloat = async function(listingId) {
             maxfloat: itemInfo.max,
             minwearfloat: wearRange[0],
             maxwearfloat: wearRange[1],
-            phase: (getDopplerPhase(itemInfo.paintindex) || '').replace('Phase', '').trim()
+            phase: (getDopplerPhase(itemInfo.paintindex) || '').replace('Phase', '').trim(),
+            low_rank: parseInt(itemInfo.low_rank),
+            high_rank: parseInt(itemInfo.high_rank)
         };
 
         if (!isInventoryPage()) {

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -216,6 +216,8 @@ class Filters {
             
             <b>Note: </b> If multiple filters match an item, it will be highlighted with the average colour<br><br>
             
+            <b>New: </b> You can now filter based on FloatDB ranks!<br><br>
+            
             <b>Examples: </b>
             <ul>
               <li>float < 0.3</li>
@@ -234,6 +236,10 @@ class Filters {
               <li>float == 0.2 or (seed > 500 and float < 0.15)</li>
                 <ul>
                     <li>Matches items with floats of 0.2 or paint seeds greater than 500 and floats less than 0.15</li>
+                </ul>
+              <li>low_rank < 500 </li>
+                <ul>
+                    <li>Matches items with floats ranked in the top 500 lowest for this skin on FloatDB</li>
                 </ul>
                <li>match(float, "7355608") >= 1</li>
                 <ul>
@@ -260,6 +266,14 @@ class Filters {
               <li>seed</li>
                 <ul>
                     <li>The paint seed of the item</li>
+                </ul>
+              <li>low_rank</li>
+                <ul>
+                    <li>If the item is in the top 1000 lowest float for this skin and category (normal, stattrak, souvenir), this is the FloatDB rank</li>
+                </ul>
+              <li>high_rank</li>
+                <ul>
+                    <li>If the item is in the top 1000 highest float for this skin and category (normal, stattrak, souvenir), this is the FloatDB rank</li>
                 </ul>
               <li>phase</li>
                 <ul>

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -237,7 +237,7 @@ class Filters {
                 <ul>
                     <li>Matches items with floats of 0.2 or paint seeds greater than 500 and floats less than 0.15</li>
                 </ul>
-              <li>low_rank < 500 </li>
+              <li>low_rank <= 500 </li>
                 <ul>
                     <li>Matches items with floats ranked in the top 500 lowest for this skin on FloatDB</li>
                 </ul>


### PR DESCRIPTION
* Shows item rank if in top 1000 for either low or high float for that specific skin and category on FloatDB
* Adds a gold/silver/bronze inventory box if in the top 1/2-3/4-5
* Fixes inventory box float showing on default selection on page load (#62)
* Allows filtering for rank (`low_rank`, `high_rank`)

Closes #62