### PR TITLE
Prevents Auto Retrying Failed CSGOFloat Requests

### DIFF
--- a/float.js
+++ b/float.js
@@ -410,6 +410,9 @@ const addInventoryMods = async function(boxContent) {
     gameInfo.parentElement.insertBefore(floatDiv, gameInfo.nextSibling);
 
     const getFloatButton = createButton('Fetching...', 'green', 'getFloatBtn');
+    getFloatButton.addEventListener('click', () => {
+        queue.addJob(inspectLink, id, /* force */ true);
+    });
     getFloatButton.inspectLink = inspectLink;
     floatDiv.appendChild(getFloatButton);
 
@@ -570,7 +573,7 @@ const addMarketButtons = async function() {
 
         let getFloatButton = createButton('Get Float', 'green', 'getFloatBtn');
         getFloatButton.addEventListener('click', () => {
-            queue.addJob(inspectLink, id);
+            queue.addJob(inspectLink, id, /* force */ true);
         });
         getFloatButton.style.marginRight = '10px';
         floatDiv.appendChild(getFloatButton);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,12 +2,13 @@
 class Queue {
     constructor() {
         this.queue = [];
+        this.failedRequests = [];
         this.running = false;
         this.concurrency = 10;
         this.processing = 0;
     }
 
-    addJob(link, listingId) {
+    addJob(link, listingId, force) {
         if (listingId in floatData) {
             showFloat(listingId);
             return;
@@ -21,6 +22,13 @@ class Queue {
         // Stop if this item is already in the queue
         if (this.queue.find(j => j.listingId === listingId)) {
             return;
+        }
+
+        if (!force) {
+            // Prevent us from auto-fetching a previously failed request unless it's a user action
+            if (this.failedRequests.find(v => v === listingId)) {
+                return;
+            }
         }
 
         const promise = new Promise((resolve, reject) => {
@@ -75,6 +83,8 @@ class Queue {
                 if (floatDiv && floatDiv.querySelector('.floatmessage')) {
                     floatDiv.querySelector('.floatmessage').innerText = data.error || 'Unknown Error';
                 }
+
+                this.failedRequests.push(job.listingId);
             }
 
             this.processing -= 1;


### PR DESCRIPTION
Additionally allows the user to explicitly force a float request if it failed.

This is required due to potential rate limit bans on Cloudflare's end when a user requests too many things at once. Further mitigations such as batching requests may be required in the future.